### PR TITLE
Add padding and free sizing to HelpWindow

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -58,7 +58,6 @@ public class HelpWindow extends UiPart<Stage> {
             double deltaY = event.getDeltaY() * 3; // * 3 to make the scrolling a bit faster
             double height = mdfx.getBoundsInLocal().getHeight();
             double vvalue = scrollPane.getVvalue();
-            System.out.println(vvalue - deltaY);
             scrollPane.setVvalue(vvalue - deltaY / height);
             // deltaY / height to make the scrolling equally fast regardless of the total height
         });

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -41,8 +41,8 @@ public class HelpWindow extends UiPart<Stage> {
 
         super(FXML, root);
 
-        String mdfxTxt;
         try {
+            public static final String USERGUIDE_PATH = Paths.get("docs", "UserGuide.md").toString();
             mdfxTxt = IOUtils.toString(new FileInputStream(USERGUIDE_PATH), StandardCharsets.UTF_8);
         } catch (IOException | NullPointerException e) { // could not find path
             logger.info("Invalid path! ");

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -42,8 +42,8 @@ public class HelpWindow extends UiPart<Stage> {
         super(FXML, root);
 
         try {
-            public static final String USERGUIDE_PATH = Paths.get("docs", "UserGuide.md").toString();
-            mdfxTxt = IOUtils.toString(new FileInputStream(USERGUIDE_PATH), StandardCharsets.UTF_8);
+            public static final String userGuidePath = Paths.get("docs", "UserGuide.md").toString();
+            mdfxTxt = IOUtils.toString(new FileInputStream(userGuidePath), StandardCharsets.UTF_8);
         } catch (IOException | NullPointerException e) { // could not find path
             logger.info("Invalid path! ");
             mdfxTxt = "This page is empty!";

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -10,11 +10,9 @@ import org.apache.commons.io.IOUtils;
 
 import com.sandec.mdfx.MarkdownView;
 
-import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -42,7 +40,7 @@ public class HelpWindow extends UiPart<Stage> {
         super(FXML, root);
 
         try {
-            public static final String userGuidePath = Paths.get("docs", "UserGuide.md").toString();
+            String userGuidePath = Paths.get("docs", "UserGuide.md").toString();
             mdfxTxt = IOUtils.toString(new FileInputStream(userGuidePath), StandardCharsets.UTF_8);
         } catch (IOException | NullPointerException e) { // could not find path
             logger.info("Invalid path! ");

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -7,8 +7,10 @@ import java.nio.file.Paths;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.HBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -21,23 +23,10 @@ import org.apache.commons.io.IOUtils;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    // public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
-    // public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
-
-    public static final String USERGUIDE_PATH = "..\\..\\..\\..\\..\\..\\docs\\UserGuide.md";
-
-    // public static final String TEST_PATH = "/test.md";
-
-    String mdfxTxt;
-
-
-
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
 
-
-    @FXML
-    private ScrollPane content;
+    private String mdfxTxt;
 
     /**
      * Creates a new HelpWindow.
@@ -61,17 +50,23 @@ public class HelpWindow extends UiPart<Stage> {
 
         MarkdownView mdfx = new MarkdownView(mdfxTxt);
 
-        ScrollPane content = new ScrollPane(mdfx);
+        mdfx.setPadding(new Insets(40));
 
-        content.setFitToWidth(true);
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setContent(mdfx);
+        scrollPane.setFitToWidth(true);
+        mdfx.setOnScroll(event -> {
+            double deltaY = event.getDeltaY() * 3; // * 3 to make the scrolling a bit faster
+            double height = mdfx.getBoundsInLocal().getHeight();
+            double vvalue = scrollPane.getVvalue();
+            System.out.println(vvalue - deltaY);
+            scrollPane.setVvalue(vvalue - deltaY / height);
+            // deltaY / height to make the scrolling equally fast regardless of the total height
+        });
 
-        Scene scene = new Scene(content, 700,700);
+        Scene scene = new Scene(scrollPane);
 
         root.setScene(scene);
-
-
-
-
 
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
+import javafx.event.Event;
 import javafx.fxml.FXML;
+import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
@@ -151,6 +153,7 @@ public class MainWindow extends UiPart<Stage> {
     public void handleHelp() {
         if (!helpWindow.isShowing()) {
             helpWindow.show();
+            helpWindow.focus();
         } else {
             helpWindow.focus();
         }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -4,6 +4,7 @@ import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
@@ -40,7 +41,7 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane commandBoxPlaceholder;
 
     @FXML
-    private MenuItem helpMenuItem;
+    private Menu helpMenu;
 
     @FXML
     private StackPane personListPanelPlaceholder;
@@ -77,7 +78,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     private void setAccelerators() {
-        setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
+        setAccelerator(helpMenu, KeyCombination.valueOf("F1"));
     }
 
     /**
@@ -105,6 +106,37 @@ public class MainWindow extends UiPart<Stage> {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
                 menuItem.getOnAction().handle(new ActionEvent());
+                event.consume();
+            }
+        });
+
+    }
+
+    /**
+     * Sets the accelerator of a Menu.
+     * @param keyCombination the KeyCombination value of the accelerator
+     */
+    private void setAccelerator(Menu menu, KeyCombination keyCombination) {
+        menu.setAccelerator(keyCombination);
+
+        /*
+         * TODO: the code below can be removed once the bug reported here
+         * https://bugs.openjdk.java.net/browse/JDK-8131666
+         * is fixed in later version of SDK.
+         *
+         * According to the bug report, TextInputControl (TextField, TextArea) will
+         * consume function-key events. Because CommandBox contains a TextField, and
+         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will
+         * not work when the focus is in them because the key event is consumed by
+         * the TextInputControl(s).
+         *
+         * For now, we add following event filter to capture such key events and open
+         * help window purposely so to support accelerators even when focus is
+         * in CommandBox or ResultDisplay.
+         */
+        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
+                menu.getOnAction().handle(new ActionEvent());
                 event.consume();
             }
         });

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -3,9 +3,7 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
-import javafx.event.Event;
 import javafx.fxml.FXML;
-import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import java.net.URL?>
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
-<?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
 
-<?import javafx.scene.control.ScrollPane?>
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<?import com.sandec.mdfx.MarkdownView?>
+<fx:root resizable="true" title="Help" type="javafx.stage.Stage"
+         xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1" width="800" height="600">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -19,19 +16,7 @@
       <stylesheets>
         <URL value="@HelpWindow.css" />
       </stylesheets>
-
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
-        <ScrollPane>
-
-        </ScrollPane>
-
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
-        <padding>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </padding>
-      </HBox>
+        <MarkdownView fx:id="content" />
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Label?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -27,7 +28,12 @@
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+
+          </Menu>
+          <Menu fx:id="helpMenu" mnemonicParsing="false" onAction="#handleHelp" >
+            <graphic>
+              <Label text="Help" onMouseClicked="#handleHelp"/>
+            </graphic>
           </Menu>
 
         </MenuBar>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -27,10 +27,9 @@
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
+
         </MenuBar>
 
         <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">


### PR DESCRIPTION
This PR fixes issue #96 

Changes:
- root of HelpWindow changed to resizable
- Added 20px padding to `MarkdownView`
- Set faster scrolling
- Made `Help` directly clickable on menubar
- Unused variables and lines are removed

The shortcut "F1" still works, but I couldn't make "F1" appear in the menubar.