### PR TITLE
Sort filtered contacts according to how many keywords matched

### DIFF
--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -337,7 +337,7 @@ save it with `Model#setPerson()`.
 //...
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -32,7 +32,7 @@ public interface Logic {
     ReadOnlyAddressBook getAddressBook();
 
     /** Returns an unmodifiable view of the filtered list of persons */
-    ObservableList<Person> getFilteredPersonList();
+    ObservableList<Person> getSortedAndFilteredPersonList();
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getContactDetails();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,8 +67,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Person> getFilteredPersonList() {
-        return model.getFilteredPersonList();
+    public ObservableList<Person> getSortedAndFilteredPersonList() {
+        return model.getSortedAndFilteredPersonList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -37,7 +37,7 @@ public class CopyCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
 
         Optional<Person> personToCopyOptional = lastShownList
                 .stream()

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -68,7 +68,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
+import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -20,15 +21,17 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final PersonContainsKeywordsPredicate predicate;
+    private final PersonKeywordMatchnessComparator comparator;
 
-    public FindCommand(PersonContainsKeywordsPredicate predicate) {
+    public FindCommand(PersonContainsKeywordsPredicate predicate, PersonKeywordMatchnessComparator comparator) {
         this.predicate = predicate;
+        this.comparator = comparator;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        model.updateAndSortFilteredPersonList(predicate, comparator);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -42,7 +42,7 @@ public class FindCommand extends Command {
         model.updateFilteredPersonList(predicate);
         model.sortFilteredPersonList(comparator);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getSortedAndFilteredPersonList().size()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -28,6 +28,11 @@ public class FindCommand extends Command {
         this.comparator = comparator;
     }
 
+    /**
+     * Finds and lists all persons in the contacts' list who matches any of the argument keywords.
+     * Results are sorted according to the {@code comparator}.
+     * @param model {@code Model} which the command should operate on.
+     */
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -8,8 +8,8 @@ import seedu.address.model.person.PersonContainsKeywordsPredicate;
 import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in the contacts' list who matches any of the argument keywords.
+ * Results are sorted according to the {@code comparator}.
  */
 public class FindCommand extends Command {
 
@@ -31,7 +31,8 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateAndSortFilteredPersonList(predicate, comparator);
+        model.updateFilteredPersonList(predicate);
+        model.sortFilteredPersonList(comparator);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -23,6 +23,9 @@ public class FindCommand extends Command {
     private final PersonContainsKeywordsPredicate predicate;
     private final PersonKeywordMatchnessComparator comparator;
 
+    /**
+     * Constructor for the {@code FindCommand} object.
+     */
     public FindCommand(PersonContainsKeywordsPredicate predicate, PersonKeywordMatchnessComparator comparator) {
         this.predicate = predicate;
         this.comparator = comparator;
@@ -42,10 +45,15 @@ public class FindCommand extends Command {
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
+    /**
+     * Checks whether a {@code FindCommand} is the same as another {@code FindCommand}.
+     * They must have the same {@code predicate} and the same {@code comparator} in order to be the same.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && predicate.equals(((FindCommand) other).predicate)
+                && comparator.equals(((FindCommand) other).comparator)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,7 +19,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        int listSize = model.getFilteredPersonList().size();
+        int listSize = model.getSortedAndFilteredPersonList().size();
         return new CommandResult(listSize + MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -30,7 +30,7 @@ public class ViewCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/add/AddTagToPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/add/AddTagToPersonCommand.java
@@ -55,7 +55,7 @@ public class AddTagToPersonCommand extends AddCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         Objects.requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
         target.setTargetList(lastShownList);
         Person targetPerson = target.targetPerson();
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/seedu/address/logic/commands/delete/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delete/DeletePersonCommand.java
@@ -38,7 +38,7 @@ public class DeletePersonCommand extends DeleteCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         Objects.requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
         target.setTargetList(lastShownList);
         Person personToDelete = target.targetPerson();
 

--- a/src/main/java/seedu/address/logic/commands/delete/DeletePersonsTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/delete/DeletePersonsTagCommand.java
@@ -51,7 +51,7 @@ public class DeletePersonsTagCommand extends DeleteCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         Objects.requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Person> lastShownList = model.getSortedAndFilteredPersonList();
         target.setTargetList(lastShownList);
         Person targetPerson = target.targetPerson();
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
+import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -27,7 +28,8 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] keywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList(keywords)));
+        return new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList(keywords)),
+                new PersonKeywordMatchnessComparator(Arrays.asList(keywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -10,13 +10,17 @@ import seedu.address.model.person.PersonContainsKeywordsPredicate;
 import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new {@code FindCommand} object
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the FindCommand
-     * and returns a FindCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@code FindCommand}
+     * and returns a {@code FindCommand} object for execution.
+     *
+     * The {@code PersonContainsKeywordsPredicate} and {@code PersonKeywordMatchnessComparator}
+     * are used as the conditions.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -116,9 +116,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Sorts contacts according to the {@code comparator} given.
      * {@code comparator} must not be null.
      */
-    public SortedList<Person> sortPersons(Comparator<Person> comparator) {
+    public void sortPersons(Comparator<Person> comparator) {
         requireAllNonNull(comparator);
-        return persons.sortPersons(comparator);
+        this.setPersons(persons.sortPersons(comparator));
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,14 +1,10 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,11 +6,9 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.logging.Filter;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
-import javafx.collections.transformation.SortedList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -102,15 +102,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Filters contacts according to the {@code predicate} given.
-     * {@code predicate} must not be null.
-     */
-    public FilteredList<Person> filterPersons(Predicate<Person> predicate) {
-        requireAllNonNull(predicate);
-        return persons.filterPersons(predicate);
-    }
-
-    /**
      * Sorts contacts according to the {@code comparator} given.
      * {@code comparator} must not be null.
      */

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,10 +1,16 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.logging.Filter;
 
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -95,6 +101,24 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void copyPerson(Person key) {
         persons.copy(key);
+    }
+
+    /**
+     * Filters contacts according to the {@code predicate} given.
+     * {@code predicate} must not be null.
+     */
+    public FilteredList<Person> filterPersons(Predicate<Person> predicate) {
+        requireAllNonNull(predicate);
+        return persons.filterPersons(predicate);
+    }
+
+    /**
+     * Sorts contacts according to the {@code comparator} given.
+     * {@code comparator} must not be null.
+     */
+    public SortedList<Person> sortPersons(Comparator<Person> comparator) {
+        requireAllNonNull(comparator);
+        return persons.sortPersons(comparator);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -101,15 +101,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.copy(key);
     }
 
-    /**
-     * Sorts contacts according to the {@code comparator} given.
-     * {@code comparator} must not be null.
-     */
-    public void sortPersons(Comparator<Person> comparator) {
-        requireAllNonNull(comparator);
-        this.setPersons(persons.sortPersons(comparator));
-    }
-
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -99,6 +100,12 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Sorts the filter of the filtered person list to filter by the given {@code comparator}.
+     * @throws NullPointerException if {@code comparator} is null.
+     */
+    void updateAndSortFilteredPersonList(Predicate<Person> predicate, Comparator<Person> comparator);
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -85,7 +85,7 @@ public interface Model {
     void setPerson(Person target, Person editedPerson);
 
     /** Returns an unmodifiable view of the filtered person list */
-    ObservableList<Person> getFilteredPersonList();
+    ObservableList<Person> getSortedAndFilteredPersonList();
 
     /**
      * Resets the filter of the view person list to empty.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -105,7 +105,7 @@ public interface Model {
      * Sorts the filter of the filtered person list to filter by the given {@code comparator}.
      * @throws NullPointerException if {@code comparator} is null.
      */
-    void updateAndSortFilteredPersonList(Predicate<Person> predicate, Comparator<Person> comparator);
+    void sortFilteredPersonList(Comparator<Person> comparator);
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -23,6 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
     private FilteredList<Person> contactDetails;
 
     /**
@@ -38,6 +40,7 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         contactDetails = new FilteredList<>(this.addressBook.getPersonList());
         resetContactDetails();
+        sortedPersons = filteredPersons.sorted();
     }
 
     public ModelManager() {
@@ -127,7 +130,7 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        return filteredPersons;
+        return sortedPersons;
     }
 
     @Override
@@ -139,7 +142,7 @@ public class ModelManager implements Model {
     @Override
     public void sortFilteredPersonList(Comparator<Person> comparator) {
         requireNonNull(comparator);
-        addressBook.sortPersons(comparator);
+        sortedPersons.setComparator(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -10,7 +10,6 @@ import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
-import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -139,10 +138,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateAndSortFilteredPersonList(Predicate<Person> predicate, Comparator<Person> comparator) {
+    public void sortFilteredPersonList(Comparator<Person> comparator) {
         requireNonNull(comparator);
         addressBook.sortPersons(comparator);
-        filteredPersons.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -22,7 +22,7 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
-    private FilteredList<Person> filteredPersons;
+    private final FilteredList<Person> filteredPersons;
     private FilteredList<Person> contactDetails;
 
     /**
@@ -116,7 +116,6 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,7 +24,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private final SortedList<Person> sortedPersons;
+    private final SortedList<Person> sortedAndFilteredPersons;
     private FilteredList<Person> contactDetails;
 
     /**
@@ -40,7 +40,7 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         contactDetails = new FilteredList<>(this.addressBook.getPersonList());
         resetContactDetails();
-        sortedPersons = filteredPersons.sorted();
+        sortedAndFilteredPersons = filteredPersons.sorted();
     }
 
     public ModelManager() {
@@ -129,8 +129,8 @@ public class ModelManager implements Model {
      * {@code versionedAddressBook}
      */
     @Override
-    public ObservableList<Person> getFilteredPersonList() {
-        return sortedPersons;
+    public ObservableList<Person> getSortedAndFilteredPersonList() {
+        return sortedAndFilteredPersons;
     }
 
     @Override
@@ -142,7 +142,7 @@ public class ModelManager implements Model {
     @Override
     public void sortFilteredPersonList(Comparator<Person> comparator) {
         requireNonNull(comparator);
-        sortedPersons.setComparator(comparator);
+        sortedAndFilteredPersons.setComparator(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -141,7 +141,7 @@ public class ModelManager implements Model {
     @Override
     public void updateAndSortFilteredPersonList(Predicate<Person> predicate, Comparator<Person> comparator) {
         requireNonNull(comparator);
-        filteredPersons = new FilteredList<>(addressBook.sortPersons(comparator));
+        addressBook.sortPersons(comparator);
         filteredPersons.setPredicate(predicate);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,11 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -21,7 +23,7 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
-    private final FilteredList<Person> filteredPersons;
+    private FilteredList<Person> filteredPersons;
     private FilteredList<Person> contactDetails;
 
     /**
@@ -130,11 +132,16 @@ public class ModelManager implements Model {
         return filteredPersons;
     }
 
-
-
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
+        filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateAndSortFilteredPersonList(Predicate<Person> predicate, Comparator<Person> comparator) {
+        requireNonNull(comparator);
+        filteredPersons = new FilteredList<>(addressBook.sortPersons(comparator));
         filteredPersons.setPredicate(predicate);
     }
 

--- a/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
@@ -1,0 +1,49 @@
+package seedu.address.model.person;
+
+import seedu.address.model.tag.Tag;
+
+import java.util.*;
+
+public class PersonKeywordMatchnessComparator implements Comparator<Person> {
+
+    private final List<String> keywords;
+
+    public PersonKeywordMatchnessComparator(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public int compare(Person p1, Person p2) {
+        int result1 = calculateNameMatchness(p2.getName());
+        int result2 = calculateNameMatchness(p1.getName());
+        int result = result1 - result2;
+        if (result != 0) {
+            return result;
+        }
+        result = calculateTagMatchness(p1.getTags()) - calculateTagMatchness(p2.getTags());
+        return result;
+    }
+
+    public int calculateNameMatchness(Name name) {
+        int matchness = 0;
+        for (String nameWord : name.fullName.split(" ")) {
+            matchness += keywords.stream().filter(keyword -> nameWord.toLowerCase()
+                    .equals(keyword.toLowerCase())).count();
+            matchness += keywords.stream().filter(keyword -> nameWord.toLowerCase()
+                    .contains(keyword.toLowerCase())).count();
+        }
+        return matchness;
+    }
+
+    public int calculateTagMatchness(Set<Tag> tags) {
+        int matchness = 0;
+        for (Tag tag : tags) {
+            matchness += keywords.stream().filter(keyword -> tag.tagName.toLowerCase()
+                    .equals(keyword.toLowerCase())).count();
+            matchness += keywords.stream().filter(keyword -> tag.tagName.toLowerCase()
+                    .contains(keyword.toLowerCase())).count();
+
+        }
+        return matchness;
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
@@ -1,10 +1,10 @@
 package seedu.address.model.person;
 
-import seedu.address.model.tag.Tag;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+
+import seedu.address.model.tag.Tag;
 
 /**
  * Compares two {@code Person}s according to how much their information
@@ -27,6 +27,19 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
         this.keywords = keywords;
     }
 
+    /**
+     * Compares two {@code Person}s according to how much their information
+     * (including name, phone, email, social media handles, and tags)
+     * matches the keywords (case is ignored)
+     *
+     * Priority:
+     * 1. Full name is matched exactly
+     * 2. Any word in the name is matched exactly
+     * 3. Name is matched partially
+     * 4. Tag is matched exactly
+     * 5. Tag is matched partially
+     * 6. Other information is matched
+     */
     @Override
     public int compare(Person p1, Person p2) {
         if (p1.getName().fullName.equalsIgnoreCase(String.join(" ", keywords))) {
@@ -41,7 +54,12 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
         return calculateTagMatchness(p2.getTags()) - calculateTagMatchness(p1.getTags());
     }
 
-    public int calculateNameMatchness(Name name) {
+    /**
+     * Returns an integer to represent the extent to which the {@code name} matches the keywords.
+     * 2 points for each keyword that matches a word in the name exactly;
+     * 1 point for each partial match.
+     */
+    private int calculateNameMatchness(Name name) {
         int matchness = 0;
         for (String nameWord : name.fullName.split(" ")) {
             matchness += keywords.stream().filter(keyword -> nameWord.toLowerCase()
@@ -52,7 +70,12 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
         return matchness;
     }
 
-    public int calculateTagMatchness(Set<Tag> tags) {
+    /**
+     * Returns an integer to represent the extent to which the set of tags matches the keywords.
+     * 2 points for each keyword that matches a tag exactly;
+     * 1 point for each partial match.
+     */
+    private int calculateTagMatchness(Set<Tag> tags) {
         int matchness = 0;
         for (Tag tag : tags) {
             matchness += keywords.stream().filter(keyword -> tag.tagName.toLowerCase()

--- a/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
@@ -87,4 +87,14 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
         return matchness;
     }
 
+    /**
+     * Checks whether this {@code PersonKeywordMatchnessComparator} equals another object.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PersonKeywordMatchnessComparator // instanceof handles nulls
+                && keywords.equals(((PersonKeywordMatchnessComparator) other).keywords)); // state check
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
@@ -2,8 +2,23 @@ package seedu.address.model.person;
 
 import seedu.address.model.tag.Tag;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
+/**
+ * Compares two {@code Person}s according to how much their information
+ * (including name, phone, email, social media handles, and tags)
+ * matches the keywords (case is ignored)
+ *
+ * Priority:
+ * 1. Full name is matched exactly
+ * 2. Any word in the name is matched exactly
+ * 3. Name is matched partially
+ * 4. Tag is matched exactly
+ * 5. Tag is matched partially
+ * 6. Other information is matched
+ */
 public class PersonKeywordMatchnessComparator implements Comparator<Person> {
 
     private final List<String> keywords;
@@ -14,9 +29,9 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
 
     @Override
     public int compare(Person p1, Person p2) {
-        if (p1.getName().fullName.equals(String.join(" ", keywords))) {
+        if (p1.getName().fullName.equalsIgnoreCase(String.join(" ", keywords))) {
             return -1;
-        } else if (p2.getName().fullName.equals(String.join(" ", keywords))) {
+        } else if (p2.getName().fullName.equalsIgnoreCase(String.join(" ", keywords))) {
             return 1;
         }
         int result = calculateNameMatchness(p2.getName()) - calculateNameMatchness(p1.getName());
@@ -28,7 +43,6 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
 
     public int calculateNameMatchness(Name name) {
         int matchness = 0;
-        System.out.print(String.join(" ", keywords));
         for (String nameWord : name.fullName.split(" ")) {
             matchness += keywords.stream().filter(keyword -> nameWord.toLowerCase()
                     .equals(keyword.toLowerCase())).count();

--- a/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
+++ b/src/main/java/seedu/address/model/person/PersonKeywordMatchnessComparator.java
@@ -14,18 +14,21 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
 
     @Override
     public int compare(Person p1, Person p2) {
-        int result1 = calculateNameMatchness(p2.getName());
-        int result2 = calculateNameMatchness(p1.getName());
-        int result = result1 - result2;
+        if (p1.getName().fullName.equals(String.join(" ", keywords))) {
+            return -1;
+        } else if (p2.getName().fullName.equals(String.join(" ", keywords))) {
+            return 1;
+        }
+        int result = calculateNameMatchness(p2.getName()) - calculateNameMatchness(p1.getName());
         if (result != 0) {
             return result;
         }
-        result = calculateTagMatchness(p1.getTags()) - calculateTagMatchness(p2.getTags());
-        return result;
+        return calculateTagMatchness(p2.getTags()) - calculateTagMatchness(p1.getTags());
     }
 
     public int calculateNameMatchness(Name name) {
         int matchness = 0;
+        System.out.print(String.join(" ", keywords));
         for (String nameWord : name.fullName.split(" ")) {
             matchness += keywords.stream().filter(keyword -> nameWord.toLowerCase()
                     .equals(keyword.toLowerCase())).count();
@@ -46,4 +49,5 @@ public class PersonKeywordMatchnessComparator implements Comparator<Person> {
         }
         return matchness;
     }
+
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -123,15 +123,6 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Sorts this list according to the {@code comparator} given.
-     * {@code comparator} must not be null.
-     */
-    public SortedList<Person> sortPersons(Comparator<Person> comparator) {
-        requireAllNonNull(comparator);
-        return internalList.sorted(comparator);
-    }
-
-    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,15 +3,11 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.function.Predicate;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
-import javafx.collections.transformation.SortedList;
 import seedu.address.model.ClipboardManager;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -123,15 +123,6 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Filters this list according to the {@code predicate} given.
-     * {@code predicate} must not be null.
-     */
-    public FilteredList<Person> filterPersons(Predicate<Person> predicate) {
-        requireAllNonNull(predicate);
-        return internalList.filtered(predicate);
-    }
-
-    /**
      * Sorts this list according to the {@code comparator} given.
      * {@code comparator} must not be null.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,11 +3,15 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.model.ClipboardManager;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
@@ -116,6 +120,24 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+    }
+
+    /**
+     * Filters this list according to the {@code predicate} given.
+     * {@code predicate} must not be null.
+     */
+    public FilteredList<Person> filterPersons(Predicate<Person> predicate) {
+        requireAllNonNull(predicate);
+        return internalList.filtered(predicate);
+    }
+
+    /**
+     * Sorts this list according to the {@code comparator} given.
+     * {@code comparator} must not be null.
+     */
+    public SortedList<Person> sortPersons(Comparator<Person> comparator) {
+        requireAllNonNull(comparator);
+        return internalList.sorted(comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -147,7 +147,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getSortedAndFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         contactDetailPanel = new ContactDetailPanel(logic.getContactDetails());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -62,7 +62,7 @@ public class LogicManagerTest {
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
         CommandBox commandBox = null;
-        int size = model.getFilteredPersonList().size();
+        int size = model.getSortedAndFilteredPersonList().size();
         assertCommandSuccess(listCommand, commandBox, size + ListCommand.MESSAGE_SUCCESS, model);
     }
 
@@ -88,7 +88,7 @@ public class LogicManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> logic.getSortedAndFilteredPersonList().remove(0));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -163,7 +163,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Person> getFilteredPersonList() {
+        public ObservableList<Person> getSortedAndFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -168,6 +169,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -113,24 +113,24 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getSortedAndFilteredPersonList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredList, actualModel.getSortedAndFilteredPersonList());
     }
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
      */
     public static void showPersonAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getSortedAndFilteredPersonList().size());
 
-        Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        Person person = model.getSortedAndFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredPersonList(new PersonContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
-        assertEquals(1, model.getFilteredPersonList().size());
+        assertEquals(1, model.getSortedAndFilteredPersonList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -32,7 +32,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
@@ -86,7 +86,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedAndFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeletePersonCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -96,7 +96,7 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
@@ -149,6 +149,6 @@ public class DeleteCommandTest {
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
 
-        assertTrue(model.getFilteredPersonList().isEmpty());
+        assertTrue(model.getSortedAndFilteredPersonList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -43,15 +43,15 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedAndFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Index indexLastPerson = Index.fromOneBased(model.getSortedAndFilteredPersonList().size());
+        Person lastPerson = model.getSortedAndFilteredPersonList().get(indexLastPerson.getZeroBased());
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -72,7 +72,7 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -85,7 +85,7 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
@@ -93,14 +93,14 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getSortedAndFilteredPersonList().get(0), editedPerson);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
@@ -121,7 +121,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getSortedAndFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
+import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -26,6 +28,9 @@ import seedu.address.model.person.PersonContainsKeywordsPredicate;
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private PersonKeywordMatchnessComparator dummyComparator =
+            new PersonKeywordMatchnessComparator(Collections.singletonList(""));
+
 
     @Test
     public void equals() {
@@ -34,14 +39,14 @@ public class FindCommandTest {
         PersonContainsKeywordsPredicate secondPredicate =
                 new PersonContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, dummyComparator);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, dummyComparator);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, dummyComparator);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -58,8 +63,9 @@ public class FindCommandTest {
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         PersonContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        FindCommand command = new FindCommand(predicate, dummyComparator);
         expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.sortFilteredPersonList(dummyComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
@@ -68,8 +74,9 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         PersonContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        FindCommand command = new FindCommand(predicate, dummyComparator);
         expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.sortFilteredPersonList(dummyComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -66,7 +66,7 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         expectedModel.sortFilteredPersonList(dummyComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+        assertEquals(Collections.emptyList(), model.getSortedAndFilteredPersonList());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         expectedModel.sortFilteredPersonList(dummyComparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getSortedAndFilteredPersonList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,14 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        int expectedSize = expectedModel.getFilteredPersonList().size();
+        int expectedSize = expectedModel.getSortedAndFilteredPersonList().size();
         assertCommandSuccess(new ListCommand(), model, expectedSize + ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        int expectedSize = expectedModel.getFilteredPersonList().size();
+        int expectedSize = expectedModel.getSortedAndFilteredPersonList().size();
         assertCommandSuccess(new ListCommand(), model, expectedSize + ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.delete.DeletePersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
+import seedu.address.model.person.PersonKeywordMatchnessComparator;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -87,7 +88,8 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")), commandBox);
-        assertEquals(new FindCommand(new PersonContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new PersonContainsKeywordsPredicate(keywords),
+                new PersonKeywordMatchnessComparator(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
+import seedu.address.model.person.PersonKeywordMatchnessComparator;
 
 public class FindCommandParserTest {
 
@@ -24,7 +25,8 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new PersonContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")),
+                        new PersonKeywordMatchnessComparator(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -90,7 +90,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getSortedAndFilteredPersonList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -90,8 +90,8 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class,
-                () -> modelManager.getSortedAndFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getSortedAndFilteredPersonList()
+                .remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -90,7 +90,8 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getSortedAndFilteredPersonList().remove(0));
+        assertThrows(UnsupportedOperationException.class,
+                () -> modelManager.getSortedAndFilteredPersonList().remove(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -36,20 +36,20 @@ public class TestUtil {
      * Returns the middle index of the person in the {@code model}'s person list.
      */
     public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size() / 2);
+        return Index.fromOneBased(model.getSortedAndFilteredPersonList().size() / 2);
     }
 
     /**
      * Returns the last index of the person in the {@code model}'s person list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredPersonList().size());
+        return Index.fromOneBased(model.getSortedAndFilteredPersonList().size());
     }
 
     /**
      * Returns the person in the {@code model}'s person list at {@code index}.
      */
     public static Person getPerson(Model model, Index index) {
-        return model.getFilteredPersonList().get(index.getZeroBased());
+        return model.getSortedAndFilteredPersonList().get(index.getZeroBased());
     }
 }


### PR DESCRIPTION
Changes:

- Sort the contacts based on how many keywords they match

The `FilteredList` is unmodifiable, so it cannot be sorted directly. I wrote a method `updateAndSortPersonsList` to do this. The method replaces the original `personsList` with a sorted one, and applies the `predicate` to the `filteredPersonsList` (which is sorted).

Currently, this method seems to work because the size of the `filteredPersonsList` is displayed correctly. However, the `personListPanel` is not getting updated, which I'm not sure why.

![image](https://user-images.githubusercontent.com/67496158/159219432-8378abe3-2507-4760-9de2-1da4cb5a7c95.png)
