### PR TITLE
Ensure that Contact list is always alphabetical except for searching

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_ALPHABETICAL_ORDER;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.model.Model;
@@ -19,6 +20,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.sortFilteredPersonList(COMPARATOR_ALPHABETICAL_ORDER);
         int listSize = model.getSortedAndFilteredPersonList().size();
         return new CommandResult(listSize + MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -142,7 +142,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setTag(Tag target, Tag editedTag) {
         requireNonNull(editedTag);
-
         tags.setTag(target, editedTag);
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -102,7 +102,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
         persons.setPerson(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -19,8 +19,8 @@ import seedu.address.model.tag.Tag;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
-    Comparator<Person> COMPARATOR_ALPHABETICAL_ORDER =
-            (p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
+    Comparator<Person> COMPARATOR_ALPHABETICAL_ORDER = (p1, p2) ->
+            p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
 
     Predicate<Tag> PREDICATE_SHOW_ALL_TAGS = unused -> true;
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -19,6 +19,9 @@ import seedu.address.model.tag.Tag;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Comparator<Person> COMPARATOR_ALPHABETICAL_ORDER =
+            (p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName);
+
     Predicate<Tag> PREDICATE_SHOW_ALL_TAGS = unused -> true;
 
     Predicate<Meeting> PREDICATE_SHOW_ALL_MEETINGS = unused -> true;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -143,12 +143,14 @@ public class ModelManager implements Model {
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        sortFilteredPersonList(COMPARATOR_ALPHABETICAL_ORDER);
     }
 
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
         addressBook.setPerson(target, editedPerson);
+        sortFilteredPersonList(COMPARATOR_ALPHABETICAL_ORDER);
     }
 
     //=========== Meetings tab =================================================================================

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -50,8 +50,6 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
-        //TODO did we forget to remove the following line?
-        internalList.sort((p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName));
     }
 
     /**
@@ -72,7 +70,6 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
-        internalList.sort((p1, p2) -> p1.getName().fullName.compareToIgnoreCase(p2.getName().fullName));
     }
 
     /**

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -61,15 +61,24 @@ public class AddressBookTest {
     }
 
     @Test
-    public void addPersonToTop_personAtTopOfList_returnsTrue() {
+    public void addPerson_personInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
-        assertTrue(addressBook.getPersonList().get(0).isSamePerson(ALICE));
+        assertTrue(addressBook.getPersonList().contains(ALICE));
     }
 
     @Test
-    public void addPerson_personInAddressBook_returnsTrue() {
+    public void addPerson_addressBookMaintainsAlphabeticalOrder() {
         addressBook.addPerson(ALICE);
-        assertTrue(addressBook.getPersonList().get(addressBook.getPersonList().size() - 4).isSamePerson(ALICE));
+        boolean reachedAlice = false;
+        for (Person p : addressBook.getPersonList()) {
+            if (p.equals(ALICE)) {
+                reachedAlice = true;
+            } else if (!reachedAlice) {
+                assertTrue(p.getName().fullName.compareToIgnoreCase(ALICE.getName().fullName) > 0);
+            } else {
+                assertTrue(p.getName().fullName.compareToIgnoreCase(ALICE.getName().fullName) < 0);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #186 

Changes:

- Added a static `Comparator` in `<<Interface>> Model` for alphabetical ordered names
- Applied the comparator in `ModelManager` and `ListCommand`