### PR TITLE
Fix meetings book bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/meetingcommands/ClearMeetingsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingcommands/ClearMeetingsCommand.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands.meetingcommands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.MeetingsBook;
+import seedu.address.model.Model;
+
+/**
+ * Clears the address book.
+ */
+public class ClearMeetingsCommand extends Command {
+
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_SUCCESS = "Meetings book has been cleared! ";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setMeetingsBook(new MeetingsBook());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.meetingcommands.AddMeetingCommand;
 import seedu.address.logic.commands.meetingcommands.ClearMeetingsCommand;
@@ -84,6 +85,9 @@ public class MeetingsBookParser {
 
             case HelpCommand.COMMAND_WORD:
                 return new HelpCommand();
+
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
             default:
                 return new FindMeetingCommandParser().parse(commandWord);

--- a/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -111,7 +112,14 @@ public class MeetingsBookParser {
                 || splitCommand[0].equals(EditMeetingCommand.COMMAND_WORD))
                 || command.equals(DeleteMeetingCommand.COMMAND_WORD)
                 || splitCommand[0].equals(DeleteMeetingCommand.COMMAND_WORD)
+                || command.equals(ListMeetingCommand.COMMAND_WORD)
+                || splitCommand[0].equals(ListMeetingCommand.COMMAND_WORD)
                 || command.equals(ClearMeetingsCommand.COMMAND_WORD)
-                || splitCommand[0].equals(ClearMeetingsCommand.COMMAND_WORD);
+                || splitCommand[0].equals(ClearMeetingsCommand.COMMAND_WORD)
+                || command.equals(HelpCommand.COMMAND_WORD)
+                || splitCommand[0].equals(HelpCommand.COMMAND_WORD)
+                || command.equals(ExitCommand.COMMAND_WORD)
+                || splitCommand[0].equals(ExitCommand.COMMAND_WORD);
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
@@ -6,9 +6,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.meetingcommands.AddMeetingCommand;
+import seedu.address.logic.commands.meetingcommands.ClearMeetingsCommand;
 import seedu.address.logic.commands.meetingcommands.DeleteMeetingCommand;
 import seedu.address.logic.commands.meetingcommands.EditMeetingCommand;
 import seedu.address.logic.commands.meetingcommands.FindMeetingCommand;
@@ -67,6 +67,9 @@ public class MeetingsBookParser {
             case AddMeetingCommand.COMMAND_WORD:
                 return new AddMeetingCommandParser().parse(arguments);
 
+            case ClearMeetingsCommand.COMMAND_WORD:
+                return new ClearMeetingsCommand();
+
             case EditMeetingCommand.COMMAND_WORD:
                 return new EditMeetingCommandParser().parse(arguments);
 
@@ -101,7 +104,7 @@ public class MeetingsBookParser {
                 || splitCommand[0].equals(EditMeetingCommand.COMMAND_WORD))
                 || command.equals(DeleteMeetingCommand.COMMAND_WORD)
                 || splitCommand[0].equals(DeleteMeetingCommand.COMMAND_WORD)
-                || command.equals(CopyCommand.COMMAND_WORD)
-                || splitCommand[0].equals(CopyCommand.COMMAND_WORD);
+                || command.equals(ClearMeetingsCommand.COMMAND_WORD)
+                || splitCommand[0].equals(ClearMeetingsCommand.COMMAND_WORD);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/MeetingsBookParser.java
@@ -82,6 +82,9 @@ public class MeetingsBookParser {
             case ListMeetingCommand.COMMAND_WORD:
                 return new ListMeetingCommand();
 
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
+
             default:
                 return new FindMeetingCommandParser().parse(commandWord);
             }


### PR DESCRIPTION
The fixes are as follows:
1. Fix clear command in meetings 
- Parser recognises clear as a valid command in the meetings tab
- Ensures that when `clear` is called in the meetings tab, only meetings are cleared 

2. Fix help command in meetings
- Parser recognises help as a valid command in the meetings tab

3. Fix exit command in meetings
- Parser recognises exit as a valid command in the meetings tab