### PR TITLE
Fix Meeting Link bugs

### DIFF
--- a/src/main/java/seedu/address/model/meeting/Link.java
+++ b/src/main/java/seedu/address/model/meeting/Link.java
@@ -3,6 +3,7 @@ package seedu.address.model.meeting;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+
 /**
  * Represents a Meeting's link in the meeting tab.
  * Guarantees: immutable; is valid as declared in {@link #isValidLink(String)}
@@ -16,8 +17,8 @@ public class Link {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX =
-            "^(https?|ftp|file)?(://)?[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
+    public static final String VALIDATION_REGEX = "((http|https)://)(www.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)";
+
 
     public final String link;
 
@@ -30,9 +31,6 @@ public class Link {
         requireNonNull(link);
         checkArgument(isValidLink(link.trim()), MESSAGE_CONSTRAINTS);
         StringBuilder updatedLink = new StringBuilder();
-        if (!link.contains("https://")) {
-            updatedLink.append("https://");
-        }
         updatedLink.append(link);
 
         this.link = updatedLink.toString();

--- a/src/main/java/seedu/address/model/meeting/Link.java
+++ b/src/main/java/seedu/address/model/meeting/Link.java
@@ -11,13 +11,23 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Link {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Link should not contain spaces";
-
-    /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "((http|https)://)(www.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)";
+            "Links should be in the form Protocol://Sub-domain.Domain.Top-Level Domain/Path "
+            + "and adhere to the following constraints:\n"
+            + "1. No whitespaces should be present between the protocol, sub-domain, domain, top-level domain "
+            + "and or path\n"
+            + "2. The domain name must:\n"
+            + "- Only have characters from A-Z and 0-9, and hyphens\n"
+            + "- Hyphens should not appear at the start or end\n"
+            + "- Not contain any special characters like _!@#$%^&*,\n \n"
+            + "eg. https://www.zoom.sg";
+    public static final String PROTOCOL_CHECK = "https?:\\/\\/";
+    public static final String SUBDOMAIN_CHECK = "(www\\.)?";
+    public static final String START_DOMAIN_CHECK = "([^:;><.,?/\\\'\\\"\\[\\]{}+=_.!@#$%^&*()-])";
+    public static final String MIDDLE_DOMAIN_CHECK = "[-a-zA-Z0-9]{0,253}";
+    public static final String END_DOMAIN_CHECK = "[^:;><.,?/\\\'\\\"\\[\\]{}+=_.!@#$%^&*()-]\\.";
+    public static final String TOPLEVEL_DOMAIN_AND_PATH_CHECK = "[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)";
+    public static final String VALIDATION_REGEX = PROTOCOL_CHECK + SUBDOMAIN_CHECK + START_DOMAIN_CHECK
+            + MIDDLE_DOMAIN_CHECK + END_DOMAIN_CHECK + TOPLEVEL_DOMAIN_AND_PATH_CHECK;
 
 
     public final String link;
@@ -60,5 +70,4 @@ public class Link {
     public int hashCode() {
         return link.hashCode();
     }
-
 }


### PR DESCRIPTION
Fixes the validation regex for the `Link` class under Meetings. 

The changes to the validation are as follows:
- User must now input `https://` or `http://` at the start 
- Domain names are restricted by A-Z (not case sensitive), 0-9 and hyphens (however not allowed at start or end)