### PR TITLE
Disable editing start time of meetings to the past

### DIFF
--- a/src/main/java/seedu/address/logic/commands/meetingcommands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingcommands/AddMeetingCommand.java
@@ -6,13 +6,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STARTTIME;
 
-import java.time.LocalDateTime;
-
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.StartTime;
 
 public class AddMeetingCommand extends AddCommand {
 
@@ -46,7 +45,7 @@ public class AddMeetingCommand extends AddCommand {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
         }
 
-        if (toAdd.getStartTime().startTime.isBefore(LocalDateTime.now())) {
+        if (StartTime.isInThePast(toAdd.getStartTime())) {
             throw new CommandException(MESSAGE_PAST_MEETING);
         }
 

--- a/src/main/java/seedu/address/logic/commands/meetingcommands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetingcommands/EditMeetingCommand.java
@@ -50,6 +50,7 @@ public class EditMeetingCommand extends Command {
     public static final String MESSAGE_EDIT_MEETING_SUCCESS = "Edited Meeting: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in the address book.";
+    public static final String MESSAGE_PAST_MEETING = "Cannot edit a meeting to start in the past";
 
     private final Index index;
     private final EditMeetingDescriptor editMeetingDescriptor;
@@ -80,6 +81,10 @@ public class EditMeetingCommand extends Command {
 
         if (!meetingToEdit.isSameMeeting(editedMeeting) && model.hasMeeting(editedMeeting)) {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
+        }
+
+        if (StartTime.isInThePast(editedMeeting.getStartTime())) {
+            throw new CommandException(MESSAGE_PAST_MEETING);
         }
 
         model.setMeeting(meetingToEdit, editedMeeting);

--- a/src/main/java/seedu/address/model/meeting/StartTime.java
+++ b/src/main/java/seedu/address/model/meeting/StartTime.java
@@ -39,6 +39,10 @@ public class StartTime {
         }
     }
 
+    public static boolean isInThePast(StartTime startTime) {
+        return startTime.startTime.isBefore(LocalDateTime.now());
+    }
+
     /**
      * Returns a startTime string for Storage purposes.
      */

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -78,28 +78,27 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
-    public static final String VALID_MEETING_NAME = "CS2103 Meeting";
-    public static final String VALID_NEXT_MEETING_NAME = "CS3230 Meeting";
+    public static final String VALID_MEETING_TITLE = "CS2103 Meeting";
+    public static final String VALID_NEXT_MEETING_TITLE = "CS3230 PE";
     public static final String VALID_LINK = "https://zoom.sg";
     public static final String VALID_LINK_TEAMS = "https://teams.sg";
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm");
     public static final LocalDateTime VALID_START_DATETIME =
-            LocalDateTime.parse("2020-10-10 1800", DATE_TIME_FORMATTER);
-    public static final StartTime VALID_START_TIME = new StartTime("2020-10-10 1800");
-    public static final String VALID_START_TIME_STRING = "2020-10-10 1800";
+            LocalDateTime.parse("2024-10-10 1800", DATE_TIME_FORMATTER);
+    public static final StartTime VALID_START_TIME = new StartTime("2024-10-10 1800");
+    public static final String VALID_START_TIME_STRING = "2024-10-10 1800";
 
     public static final Duration VALID_DURATION = new Duration(60);
     public static final int VALID_DURATION_INT = 60;
     public static final String VALID_DURATION_STRING = "60";
     public static final String INVALID_DURATION_STRING = "abc";
 
-    public static final String INVALID_LINK = "https://zoom.com.sg 123456";
+    public static final String INVALID_LINK = "https://zoom.sg 123456";
     public static final String INVALID_START_TIME = "2020-10-10 180";
 
 
-    public static final String MEETING_NAME_CS2103 = " " + PREFIX_NAME + VALID_MEETING_NAME;
+    public static final String MEETING_TITLE_CS2103 = " " + PREFIX_NAME + VALID_MEETING_TITLE;
     public static final String LINK_ZOOM = " " + PREFIX_LINK + VALID_LINK;
-    public static final String LINK_TEAMS = " " + PREFIX_LINK + VALID_LINK_TEAMS;
     public static final String START_TIME = " " + PREFIX_STARTTIME + VALID_START_TIME_STRING;
     public static final String DURATION = " " + PREFIX_DURATION + VALID_DURATION_STRING;
 
@@ -122,10 +121,10 @@ public class CommandTestUtil {
                 //TODO Handle descriptor with socials and no phones/emails/addresses
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        DESC_CS2103 = new EditMeetingDescriptorBuilder().withName(VALID_MEETING_NAME)
+        DESC_CS2103 = new EditMeetingDescriptorBuilder().withTitle(VALID_MEETING_TITLE)
                 .withLink(VALID_LINK).withStartTime(VALID_START_TIME)
                 .withTags(VALID_TAG_FRIEND).build();
-        DESC_CS3230 = new EditMeetingDescriptorBuilder().withName(VALID_NEXT_MEETING_NAME)
+        DESC_CS3230 = new EditMeetingDescriptorBuilder().withTitle(VALID_NEXT_MEETING_TITLE)
                 .withLink(VALID_LINK).withStartTime(VALID_START_TIME)
                 .withTags(VALID_TAG_FRIEND).build();
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingsBook;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -34,8 +34,8 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() throws CommandException {
-        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -96,10 +96,10 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() throws CommandException {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
+        Person personToDelete = model.getSortedAndFilteredPersonList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeletePersonCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
 
@@ -112,9 +112,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -125,14 +125,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeletePersonCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeletePersonCommand(INDEX_FIRST);
+        DeleteCommand deleteSecondCommand = new DeletePersonCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeletePersonCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeletePersonCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -10,8 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingsBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -42,7 +42,7 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() throws CommandException {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -84,8 +84,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST, new EditPersonDescriptor());
+        Person editedPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
@@ -97,11 +97,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() throws CommandException {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
-        Person personInFilteredList = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personInFilteredList = model.getSortedAndFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditPersonCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
@@ -115,20 +115,20 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Person firstPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person firstPerson = model.getSortedAndFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditPersonCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditPersonCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
 
         // edit person in filtered list into a duplicate in address book
-        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST_PERSON,
+        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND.getZeroBased());
+        EditCommand editCommand = new EditPersonCommand(INDEX_FIRST,
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditPersonCommand.MESSAGE_DUPLICATE_PERSON);
@@ -149,8 +149,8 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        showPersonAtIndex(model, INDEX_FIRST);
+        Index outOfBoundIndex = INDEX_SECOND;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
@@ -162,11 +162,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditPersonCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditPersonCommand(INDEX_FIRST, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditPersonCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -179,10 +179,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_SECOND, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditPersonCommand(INDEX_FIRST, DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingsBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -35,7 +35,7 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST);
         int expectedSize = expectedModel.getSortedAndFilteredPersonList().size();
         assertCommandSuccess(new ListCommand(), model, expectedSize + ListCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/meetings/DeleteMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/DeleteMeetingCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalMeetings.CS2103_MEETING;

--- a/src/test/java/seedu/address/logic/commands/meetings/DeleteMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/DeleteMeetingCommandTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalMeetings.CS2103_MEETING;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingsBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -34,8 +34,8 @@ public class DeleteMeetingCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Meeting meetingToDelete = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteMeetingCommand(INDEX_FIRST_PERSON);
+        Meeting meetingToDelete = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteMeetingCommand(INDEX_FIRST);
 
         String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete);
 
@@ -95,44 +95,15 @@ public class DeleteMeetingCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
-        showMeetingAtIndex(model, INDEX_FIRST_PERSON);
-
-        Meeting meetingToDelete = model.getSortedAndFilteredMeetingList().get((INDEX_FIRST_PERSON.getZeroBased()));
-        DeleteCommand deleteCommand = new DeleteMeetingCommand(INDEX_FIRST_PERSON);
-
-        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete);
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), model.getMeetingsBook(), new UserPrefs());
-        expectedModel.deleteMeeting(meetingToDelete);
-        showNoMeeting(expectedModel);
-
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showMeetingAtIndex(model, INDEX_FIRST_PERSON);
-
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getMeetingsBook().getMeetingList().size());
-
-        DeleteCommand deleteCommand = new DeleteMeetingCommand(outOfBoundIndex);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-    }
-
-    @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteMeetingCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteMeetingCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteMeetingCommand(INDEX_FIRST);
+        DeleteCommand deleteSecondCommand = new DeleteMeetingCommand(INDEX_SECOND);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteMeetingCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteMeetingCommand(INDEX_FIRST);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/meetings/EditMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/EditMeetingCommandTest.java
@@ -5,14 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_CS2103;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_CS3230;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_TITLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 import static seedu.address.testutil.TypicalMeetings.getTypicalMeetingsBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -40,10 +39,10 @@ public class EditMeetingCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalMeetingsBook(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void execute_allFieldsSpecified_success() {
         Meeting editedMeeting = new MeetingBuilder().build();
         EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder(editedMeeting).build();
-        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST_PERSON, descriptor);
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
 
@@ -55,7 +54,7 @@ public class EditMeetingCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+    public void execute_someFieldsSpecified_success() {
         Index indexLastMeeting = Index.fromOneBased(model.getSortedAndFilteredMeetingList().size());
         Meeting lastMeeting = model.getSortedAndFilteredMeetingList().get(indexLastMeeting.getZeroBased());
 
@@ -63,7 +62,7 @@ public class EditMeetingCommandTest {
         Meeting editedMeeting = meetingInList.withTitle(VALID_NAME_BOB).withLink(VALID_LINK)
                 .withTags(VALID_TAG_HUSBAND).build();
 
-        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withName(VALID_NAME_BOB)
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_NAME_BOB)
                 .withLink(VALID_LINK).withTags(VALID_TAG_HUSBAND).build();
         EditMeetingCommand editCommand = new EditMeetingCommand(indexLastMeeting, descriptor);
 
@@ -77,9 +76,9 @@ public class EditMeetingCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST_PERSON, new EditMeetingDescriptor());
-        Meeting editedMeeting = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST_PERSON.getZeroBased());
+    public void execute_noFieldSpecified_success() {
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST, new EditMeetingDescriptor());
+        Meeting editedMeeting = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
 
         String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
 
@@ -90,77 +89,30 @@ public class EditMeetingCommandTest {
     }
 
     @Test
-    public void execute_filteredList_success() {
-        showMeetingAtIndex(model, INDEX_FIRST_PERSON);
-
-        Meeting meetingInFilteredList = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Meeting editedMeeting = new MeetingBuilder(meetingInFilteredList).withTitle(VALID_MEETING_NAME).build();
-        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST_PERSON,
-                new EditMeetingDescriptorBuilder().withName(VALID_MEETING_NAME).build());
-
-        String expectedMessage = String.format(EditMeetingCommand.MESSAGE_EDIT_MEETING_SUCCESS, editedMeeting);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new MeetingsBook(model.getMeetingsBook()), new UserPrefs());
-        expectedModel.setMeeting(model.getSortedAndFilteredMeetingList().get(0), editedMeeting);
-
-        assertCommandSuccess(editMeetingCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_duplicateMeetingUnfilteredList_failure() {
-        Meeting firstMeeting = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST_PERSON.getZeroBased());
+    public void execute_duplicateMeeting_failure() {
+        Meeting firstMeeting = model.getSortedAndFilteredMeetingList().get(INDEX_FIRST.getZeroBased());
         EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder(firstMeeting).build();
-        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_SECOND_PERSON, descriptor);
+        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_SECOND, descriptor);
 
         assertCommandFailure(editMeetingCommand, model, EditMeetingCommand.MESSAGE_DUPLICATE_MEETING);
     }
 
     @Test
-    public void execute_duplicateMeetingFilteredList_failure() {
-        showMeetingAtIndex(model, INDEX_FIRST_PERSON);
-
-        // edit person in filtered list into a duplicate in address book
-        Meeting meetingInList = model.getMeetingsBook().getMeetingList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditMeetingCommand editMeetingCommand = new EditMeetingCommand(INDEX_FIRST_PERSON,
-                new EditMeetingDescriptorBuilder(meetingInList).build());
-
-        assertCommandFailure(editMeetingCommand, model, EditMeetingCommand.MESSAGE_DUPLICATE_MEETING);
-    }
-
-    @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
+    public void execute_invalidMeetingIndex_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getSortedAndFilteredMeetingList().size() + 1);
-        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditMeetingDescriptor descriptor = new EditMeetingDescriptorBuilder().withTitle(VALID_MEETING_TITLE).build();
         EditMeetingCommand editMeetingCommand = new EditMeetingCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editMeetingCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
-    /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of address book
-     */
-    @Test
-    public void execute_invalidMeetingIndexFilteredList_failure() {
-        showMeetingAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getMeetingsBook().getMeetingList().size());
-
-        EditMeetingCommand editCommand = new EditMeetingCommand(outOfBoundIndex,
-                new EditMeetingDescriptorBuilder().withName(VALID_NAME_BOB).build());
-
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-    }
-
     @Test
     public void equals() {
-        final EditMeetingCommand standardCommand = new EditMeetingCommand(INDEX_FIRST_PERSON, DESC_CS2103);
+        final EditMeetingCommand standardCommand = new EditMeetingCommand(INDEX_FIRST, DESC_CS2103);
 
         // same values -> returns true
         EditMeetingDescriptor copyDescriptor = new EditMeetingDescriptorBuilder(DESC_CS2103).build();
-        EditMeetingCommand commandWithSameValues = new EditMeetingCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditMeetingCommand commandWithSameValues = new EditMeetingCommand(INDEX_FIRST, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -173,10 +125,10 @@ public class EditMeetingCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_SECOND_PERSON, DESC_CS2103)));
+        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_SECOND, DESC_CS2103)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_FIRST_PERSON, DESC_CS3230)));
+        assertFalse(standardCommand.equals(new EditMeetingCommand(INDEX_FIRST, DESC_CS3230)));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/meetings/FindMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/FindMeetingCommandTest.java
@@ -79,7 +79,7 @@ public class FindMeetingCommandTest {
         expectedModel.updateFilteredMeetingList(predicate);
         expectedModel.sortFilteredMeetingList(comparator);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CS2103_MEETING, CS3230_MEETING), model.getSortedAndFilteredMeetingList());
+        assertEquals(Arrays.asList(CS2103_MEETING, CS3230_PE), model.getSortedAndFilteredMeetingList());
     }
      */
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.Arrays;
@@ -57,8 +57,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_deleteIndex() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(), commandBox);
-        assertEquals(new DeletePersonCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST.getOneBased(), commandBox);
+        assertEquals(new DeletePersonCommand(INDEX_FIRST), command);
     }
 
     @Test
@@ -73,9 +73,9 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " "
+                + INDEX_FIRST.getOneBased() + " "
                 + PersonUtil.getEditPersonDescriptorDetails(descriptor), commandBox);
-        assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditPersonCommand(INDEX_FIRST, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validIndex_returnsIndexedDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeletePersonCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1", new DeletePersonCommand(INDEX_FIRST));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -26,9 +26,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD;
 
 import org.junit.jupiter.api.Test;
 
@@ -109,7 +109,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
                 + EMAIL_DESC_AMY// + ADDRESS_DESC_AMY
                 + NAME_DESC_AMY + SOCIAL_DESC_GMAIL + TAG_DESC_FRIEND + SOCIAL_DESC_TELEGRAM;
@@ -125,7 +125,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
@@ -138,7 +138,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // name
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
         EditCommand expectedCommand = new EditPersonCommand(targetIndex, descriptor);
@@ -167,7 +167,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
@@ -183,7 +183,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
         EditCommand expectedCommand = new EditPersonCommand(targetIndex, descriptor);
@@ -201,7 +201,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_resetTags_success() {
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,10 +50,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST, ParserUtil.parseIndex("  1  "));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/meetings/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/meetings/AddMeetingCommandParserTest.java
@@ -5,7 +5,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_DURATION_DESC
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LINK_ZOOM;
-import static seedu.address.logic.commands.CommandTestUtil.MEETING_NAME_CS2103;
+import static seedu.address.logic.commands.CommandTestUtil.MEETING_TITLE_CS2103;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_INT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DURATION_STRING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_TITLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATETIME;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_START_TIME_STRING;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -37,25 +37,25 @@ public class AddMeetingCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() throws ParseException {
-        Meeting expectedMeeting = new MeetingBuilder().withTitle(VALID_MEETING_NAME)
+        Meeting expectedMeeting = new MeetingBuilder().withTitle(VALID_MEETING_TITLE)
                 .withLink(VALID_LINK).withStartTime(VALID_START_TIME_STRING)
                 .withDuration(VALID_DURATION_INT).withTags(VALID_TAG_FRIEND).build();
 
         // multiple links - last link accepted
-        assertParseSuccess(parser, MEETING_NAME_CS2103 + LINK_ZOOM + START_TIME + DURATION
+        assertParseSuccess(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + START_TIME + DURATION
                 + TAG_DESC_FRIEND, new AddMeetingCommand(expectedMeeting));
 
 
         // multiple end dateTime - last end dateTime accepted
-        assertParseSuccess(parser, MEETING_NAME_CS2103 + LINK_ZOOM + START_TIME + DURATION
+        assertParseSuccess(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + START_TIME + DURATION
                 + TAG_DESC_FRIEND + TAG_DESC_FRIEND, new AddMeetingCommand(expectedMeeting));
 
         // multiple tags - all accepted
         Meeting expectedMeetingMultipleTags = new MeetingBuilder()
-                .withTitle(VALID_MEETING_NAME).withLink(VALID_LINK).withStartTime(VALID_START_TIME_STRING)
+                .withTitle(VALID_MEETING_TITLE).withLink(VALID_LINK).withStartTime(VALID_START_TIME_STRING)
                 .withDuration(VALID_DURATION_INT).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        assertParseSuccess(parser, MEETING_NAME_CS2103 + LINK_ZOOM + START_TIME + DURATION
+        assertParseSuccess(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + START_TIME + DURATION
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddMeetingCommand(expectedMeetingMultipleTags));
 
     }
@@ -66,7 +66,7 @@ public class AddMeetingCommandParserTest {
         // zero tags
         Meeting expectedMeeting = new MeetingBuilder(CS2103_MEETING).withLink(VALID_LINK)
                 .withDateTime(VALID_START_DATETIME, VALID_END_DATETIME).withTags().build();
-        assertParseSuccess(parser, MEETING_NAME_CS2103 + LINK_ZOOM + START_DATE_TIME + END_DATE_TIME,
+        assertParseSuccess(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + START_DATE_TIME + END_DATE_TIME,
                 new AddMeetingCommand(expectedMeeting));
     }
      */
@@ -76,48 +76,48 @@ public class AddMeetingCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_MEETING_NAME + LINK_ZOOM + START_TIME + DURATION,
+        assertParseFailure(parser, VALID_MEETING_TITLE + LINK_ZOOM + START_TIME + DURATION,
                 expectedMessage);
 
         // missing link prefix
-        assertParseFailure(parser, MEETING_NAME_CS2103 + VALID_LINK + START_TIME + DURATION,
+        assertParseFailure(parser, MEETING_TITLE_CS2103 + VALID_LINK + START_TIME + DURATION,
                 expectedMessage);
 
         // missing start dateTime prefix
-        assertParseFailure(parser, MEETING_NAME_CS2103 + LINK_ZOOM + VALID_START_TIME_STRING + DURATION,
+        assertParseFailure(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + VALID_START_TIME_STRING + DURATION,
                 expectedMessage);
 
         // missing duration prefix
-        assertParseFailure(parser, VALID_MEETING_NAME + LINK_ZOOM + START_TIME + VALID_DURATION_STRING,
+        assertParseFailure(parser, VALID_MEETING_TITLE + LINK_ZOOM + START_TIME + VALID_DURATION_STRING,
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_MEETING_NAME + VALID_LINK + VALID_START_DATETIME + VALID_DURATION_STRING,
+        assertParseFailure(parser, VALID_MEETING_TITLE + VALID_LINK + VALID_START_DATETIME + VALID_DURATION_STRING,
                 expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid link
-        assertParseFailure(parser, MEETING_NAME_CS2103 + INVALID_LINK_DESC + START_TIME + DURATION
+        assertParseFailure(parser, MEETING_TITLE_CS2103 + INVALID_LINK_DESC + START_TIME + DURATION
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Link.MESSAGE_CONSTRAINTS);
 
         // invalid start time
-        assertParseFailure(parser, MEETING_NAME_CS2103 + LINK_ZOOM + INVALID_START_TIME_DESC + DURATION
+        assertParseFailure(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + INVALID_START_TIME_DESC + DURATION
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, StartTime.MESSAGE_CONSTRAINTS);
 
         // invalid duration
-        assertParseFailure(parser, MEETING_NAME_CS2103 + LINK_ZOOM + START_TIME + INVALID_DURATION_DESC
+        assertParseFailure(parser, MEETING_TITLE_CS2103 + LINK_ZOOM + START_TIME + INVALID_DURATION_DESC
                 + VALID_TAG_FRIEND, Duration.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, MEETING_NAME_CS2103
+        assertParseFailure(parser, MEETING_TITLE_CS2103
                         + INVALID_LINK_DESC + INVALID_START_TIME_DESC// + INVALID_ADDRESS_DESC,
                         + DURATION + VALID_TAG_FRIEND,
                 Link.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + MEETING_NAME_CS2103 + LINK_ZOOM + START_TIME
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + MEETING_TITLE_CS2103 + LINK_ZOOM + START_TIME
                         + DURATION + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalMeetings.CS2103_MEETING;
-import static seedu.address.testutil.TypicalMeetings.CS3230_MEETING;
+import static seedu.address.testutil.TypicalMeetings.CS3230_PE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
-import seedu.address.testutil.MeetingsTabBuilder;
+import seedu.address.testutil.MeetingsBookBuilder;
 
 public class ModelManagerTest {
 
@@ -102,8 +102,8 @@ public class ModelManagerTest {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
-        MeetingsBook meetingsTab = new MeetingsTabBuilder().withMeeting(CS2103_MEETING)
-                .withMeeting(CS3230_MEETING).build();
+        MeetingsBook meetingsTab = new MeetingsBookBuilder().withMeeting(CS2103_MEETING)
+                .withMeeting(CS3230_PE).build();
         MeetingsBook differentMeetingsTab = new MeetingsBook();
 
         // same values -> returns true

--- a/src/test/java/seedu/address/testutil/EditMeetingDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditMeetingDescriptorBuilder.java
@@ -42,7 +42,7 @@ public class EditMeetingDescriptorBuilder {
     /**
      * Sets the {@code Name} of the {@code EditPersonDescriptor} that we are building.
      */
-    public EditMeetingDescriptorBuilder withName(String title) {
+    public EditMeetingDescriptorBuilder withTitle(String title) {
         descriptor.setTitle(new Title(title));
         return this;
     }

--- a/src/test/java/seedu/address/testutil/MeetingBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingBuilder.java
@@ -17,7 +17,7 @@ import seedu.address.model.util.SampleDataUtil;
  */
 public class MeetingBuilder {
 
-    public static final String DEFAULT_NAME = "Project Meeting";
+    public static final String DEFAULT_TITLE = "Project Meeting";
     public static final String DEFAULT_LINK = "https://zoom.sg";
     public static final String DEFAULT_START_TIME = "2024-10-10 1800";
     private static final int DEFAULT_DURATION = 60;
@@ -32,7 +32,7 @@ public class MeetingBuilder {
      * Creates a {@code MeetingBuilder} with the default details.
      */
     public MeetingBuilder() {
-        title = new Title(DEFAULT_NAME);
+        title = new Title(DEFAULT_TITLE);
         link = new Link(DEFAULT_LINK);
         startTime = new StartTime(DEFAULT_START_TIME);
         duration = new Duration(DEFAULT_DURATION);

--- a/src/test/java/seedu/address/testutil/MeetingsBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/MeetingsBookBuilder.java
@@ -8,22 +8,22 @@ import seedu.address.model.meeting.Meeting;
  * Example usage: <br>
  *     {@code AddressBook ab = new AddressBookBuilder().withPerson("John", "Doe").build();}
  */
-public class MeetingsTabBuilder {
+public class MeetingsBookBuilder {
 
     private MeetingsBook meetingsBook;
 
-    public MeetingsTabBuilder() {
+    public MeetingsBookBuilder() {
         meetingsBook = new MeetingsBook();
     }
 
-    public MeetingsTabBuilder(MeetingsBook meetingsBook) {
+    public MeetingsBookBuilder(MeetingsBook meetingsBook) {
         this.meetingsBook = meetingsBook;
     }
 
     /**
      * Adds a new {@code Person} to the {@code AddressBook} that we are building.
      */
-    public MeetingsTabBuilder withMeeting(Meeting meeting) {
+    public MeetingsBookBuilder withMeeting(Meeting meeting) {
         meetingsBook.addMeeting(meeting);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD = Index.fromOneBased(3);
 }

--- a/src/test/java/seedu/address/testutil/TypicalMeetings.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetings.java
@@ -1,23 +1,11 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SOCIAL_GMAIL;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SOCIAL_TELEGRAM;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.MeetingsBook;
 import seedu.address.model.meeting.Meeting;
-import seedu.address.model.person.Person;
 
 /**
  * A utility class containing a list of {@code Person} objects to be used in tests.

--- a/src/test/java/seedu/address/testutil/TypicalMeetings.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetings.java
@@ -26,39 +26,21 @@ public class TypicalMeetings {
 
     public static final Meeting CS2103_MEETING = new MeetingBuilder().withTitle("CS2103 Meeting")
             .withLink("https://zoom.sg")
-            .withStartTime("2018-10-10 1800")
-            .withDuration(60)
+            .withStartTime("2022-3-7 1800")
+            .withDuration(120)
             .withTags("cs2103").build();
-    public static final Meeting CS3230_MEETING = new MeetingBuilder().withTitle("CS3230 Meeting")
+    public static final Meeting CS3230_PE = new MeetingBuilder().withTitle("CS3230 PE")
             .withLink("https://zoom.sg")
-            .withStartTime("2019-10-10 1800")
+            .withStartTime("2022-4-14 0900")
             .withDuration(60)
             .withTags("cs3230").build();
-    public static final Meeting PROJECT_MEETING = new MeetingBuilder().withTitle("Project Meeting")
+    public static final Meeting CS2103_FINAL = new MeetingBuilder().withTitle("CS2103 Final")
             .withLink("https://zoom.sg")
-            .withStartTime("2020-10-10 1800")
-            .withDuration(50)
-            .withTags("project").build();
+            .withStartTime("2022-5-5 1700")
+            .withDuration(150)
+            .withTags("final", "cs2103").build();
 
-    // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com")
-            .build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com")
-            .build();
-
-    // Manually added - Person's details found in {@code CommandTestUtil}
-    public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY)
-            .withSocials(VALID_SOCIAL_GMAIL)
-            .withTags(VALID_TAG_FRIEND).build();
-    public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB)//.withAddress(VALID_ADDRESS_BOB)
-            .withSocials(VALID_SOCIAL_TELEGRAM, VALID_SOCIAL_GMAIL)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-
-    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
+    public static final String KEYWORD_MATCHING_MEIER = "cs2103"; // A keyword that matches cs2103
 
     private TypicalMeetings() {} // prevents instantiation
 
@@ -66,14 +48,14 @@ public class TypicalMeetings {
      * Returns an {@code MeetingsTab} with all the typical meetings.
      */
     public static MeetingsBook getTypicalMeetingsBook() {
-        MeetingsBook ab = new MeetingsBook();
+        MeetingsBook mb = new MeetingsBook();
         for (Meeting meeting : getTypicalMeetings()) {
-            ab.addMeeting(meeting);
+            mb.addMeeting(meeting);
         }
-        return ab;
+        return mb;
     }
 
     public static List<Meeting> getTypicalMeetings() {
-        return new ArrayList<>(Arrays.asList(CS2103_MEETING, CS3230_MEETING, PROJECT_MEETING));
+        return new ArrayList<>(Arrays.asList(CS2103_MEETING, CS3230_PE, CS2103_FINAL));
     }
 }


### PR DESCRIPTION
This PR fixes #158 and fixes #168

Changes:

The target start time is checked in `AddMeetingCommand` and `EditMeetingCommand` using `StartTime.isInThePast()`. Target start time in the past is rejected.

Changes in tests:

- Removed tests using filtered meetings list
- Refactore typical indexes for both meetings and persons
- Modified typical meeting book to include future and past meetings
