### PR TITLE
Fix Email regex

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -12,12 +12,13 @@ public class Email {
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special "
+            + "1. The email has a length of at most 254 characters.\n"
+            + "2. The local-part should only contain at most 64 alphanumeric characters and these special "
             + "characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
-            + "separated by periods.\n"
+            + "3. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
+            + "separated by periods\n"
             + "The domain name must:\n"
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
@@ -25,7 +26,7 @@ public class Email {
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "(([[" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + "])*" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
+            + ALPHANUMERIC_NO_UNDERSCORE + "]){0,62}" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(" + "([-" + ALPHANUMERIC_NO_UNDERSCORE + "])*" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
     private static final String DOMAIN_LAST_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE + "([-"
@@ -50,7 +51,8 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.equals("-") || test.matches(VALIDATION_REGEX);
+        return test.equals("-") 
+            || (test.matches(VALIDATION_REGEX) && test.length() <= 254);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -51,7 +51,7 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.equals("-") 
+        return test.equals("-")
             || (test.matches(VALIDATION_REGEX) && test.length() <= 254);
     }
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -12,7 +12,8 @@ public class Email {
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. The local-part should only contain alphanumeric characters and these special "
+            + "characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
@@ -22,12 +23,13 @@ public class Email {
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]"; // alphanumeric characters except underscore
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "(([[" + SPECIAL_CHARACTERS + "]"
+            + ALPHANUMERIC_NO_UNDERSCORE + "])*" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
+            + "(" + "([-" + ALPHANUMERIC_NO_UNDERSCORE + "])*" + ALPHANUMERIC_NO_UNDERSCORE + ")?";
+    private static final String DOMAIN_LAST_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE + "([-"
+            + ALPHANUMERIC_NO_UNDERSCORE + "])*" + ALPHANUMERIC_NO_UNDERSCORE;
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -26,7 +26,7 @@ public class EmailTest {
         String validEmail_length_254 = "a@" + "a".repeat(248) + ".com";
         String invalidEmail_localPart65 = "a".repeat(65) + "@gmail.com";
         String invalidEmail_length_255 = "aa@" + "a".repeat(248) + ".com";
-        
+
         assert validEmail_length_254.length() == 254;
         assert invalidEmail_length_255.length() == 255;
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -22,6 +22,14 @@ public class EmailTest {
     @Test
     public void isValidEmail() {
 
+        String validEmail_localPart64 = "a".repeat(64) + "@gmail.com";
+        String validEmail_length_254 = "a@" + "a".repeat(248) + ".com";
+        String invalidEmail_localPart65 = "a".repeat(65) + "@gmail.com";
+        String invalidEmail_length_255 = "aa@" + "a".repeat(248) + ".com";
+        
+        assert validEmail_length_254.length() == 254;
+        assert invalidEmail_length_255.length() == 255;
+
         // null email
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
@@ -51,6 +59,8 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail(invalidEmail_length_255)); //invalid email length
+        assertFalse(Email.isValidEmail(invalidEmail_localPart65)); //invalid local part length
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -71,5 +81,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
         assertTrue(Email.isValidEmail("e1234567@u.n.u.s.edu")); // more than one 1-char domain-part
         assertTrue(Email.isValidEmail("e1234567@u.n.u.s.ed")); // more than one 1-char domain- and 2 letter TLD
+        assertTrue(Email.isValidEmail(validEmail_length_254));
+        assertTrue(Email.isValidEmail(validEmail_localPart64));
     }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -21,6 +21,7 @@ public class EmailTest {
 
     @Test
     public void isValidEmail() {
+
         // null email
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
@@ -44,7 +45,6 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -57,12 +57,19 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
+        assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
+        assertTrue(Email.isValidEmail("peter--jack@example.com")); // local part has two consecutive hypens
+        assertTrue(Email.isValidEmail("peter__jack@example.com")); // local part has two consecutive hypens
         assertTrue(Email.isValidEmail("a@bc")); // minimal
         assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
         assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
+        assertTrue(Email.isValidEmail("if_you_dream_it_you.can.do.it@example.com")); // many underscores
+        assertTrue(Email.isValidEmail("peter_jack@very--a--example.com")); // many hypens in domain
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("e1234567@u.n.u.s.edu")); // more than one 1-char domain-part
+        assertTrue(Email.isValidEmail("e1234567@u.n.u.s.ed")); // more than one 1-char domain- and 2 letter TLD
     }
 }


### PR DESCRIPTION
Previously, emails such as `peter__jack@example.com` are considered invalid emails. However, emails with consecutive special chars (especially consecutive underscores) do exist and are somewhat common.

Also, fix #195 by adhering to the RFC guidelines of 64 chars for the local part and overall 254 chars for the email.