### PR TITLE
Fix edit social media index out of bounds

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
+    public static final String MESSAGE_INVALID_SOCIAL_MEDIA_DISPLAYED_INDEX =
+            "The social media index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Searched for %1$s, %2$d persons listed!";
     public static final String MESSAGE_CONTACT_DETAILS = "Details of %1$s shown!";
     public static final String MESSAGE_MEETINGS_LISTED_OVERVIEW = "%1$d meetings listed!";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.edit.EditPersonCommand;
+import seedu.address.logic.commands.edit.EditSocialMediaCommand;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -21,9 +23,12 @@ import seedu.address.model.tag.Tag;
 public abstract class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified.\n"
             + "Specify the person to edit by their fullname or "
-            + "by the index number used in the displayed person list.";
+            + "by the index number used in the displayed person list. Try either:\n"
+            + "1. Editing a person: " + COMMAND_WORD + " " + EditPersonCommand.EDIT_PERSON_COMMAND_PARAMS
+            + "2. Editing a person's social media: "
+            + COMMAND_WORD + " " + EditSocialMediaCommand.EDIT_SOCIAL_MEDIA_COMMAND_PARAMS;
 
     /**
      * Stores the details to edit the person with. Each non-empty field value will replace the

--- a/src/main/java/seedu/address/logic/commands/edit/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditPersonCommand.java
@@ -20,18 +20,21 @@ import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
 public class EditPersonCommand extends EditCommand {
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+
+    public static final String EDIT_PERSON_COMMAND_PARAMS = "<NAME or INDEX (must be a positive integer)> "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            // + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_SOCIAL_MEDIA + "PLATFORM, PLATFORM_DESCRIPTION]...\n"
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_SOCIAL_MEDIA + "PLATFORM, PLATFORM_DESCRIPTION]... "
+            + "[" + PREFIX_TAG + "TAG]...\n";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+            + "by the index number used in the displayed person list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: " + EDIT_PERSON_COMMAND_PARAMS
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 ";
+
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SOCIAL_MEDIA;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.EditCommand;
@@ -23,13 +24,17 @@ public class EditSocialMediaCommand extends EditCommand {
 
     public static final String MESSAGE_EDIT_SOCIALS_SUCCESS = "Edited social media of %s: From %s to %s";
     public static final String MESSAGE_SOCIALS_ALREADY_EXISTS = "Socials %s already exists in %s!";
+    public static final String EDIT_SOCIAL_MEDIA_COMMAND_PARAMS = "<PERSON_NAME or INDEX> "
+            + PREFIX_INDEX + "INDEX_NUM "
+            + PREFIX_SOCIAL_MEDIA + "UPDATED_VALUE "
+            + "[" + PREFIX_PLATFORM_NAME_FLAG + " ]\n";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the targeted social media of a given person. "
             + "The social media is specified by the index of list of socials of the given person.\n"
-            + "Parameters:"
-            + "PERSON_NAME/INDEX"
-            + PREFIX_INDEX + "INDEX_NUM"
-            + "[" + PREFIX_PLATFORM_NAME_FLAG + "]"
-            + PREFIX_SOCIAL_MEDIA + "UPDATED_VALUE";
+            + "Parameters: "
+            + EDIT_SOCIAL_MEDIA_COMMAND_PARAMS
+            + "Example: "
+            + COMMAND_WORD + " Alex Yeoh " + PREFIX_INDEX + "1 " + PREFIX_PLATFORM_NAME_FLAG
+            + " " + PREFIX_SOCIAL_MEDIA + "Telegram";
 
     private Target target;
     private Index index;

--- a/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
@@ -91,4 +91,18 @@ public class EditSocialMediaCommand extends EditCommand {
                 updatedPerson.getName(), socialMediaToEdit, updatedSocialMedia));
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof EditSocialMediaCommand) {
+            EditSocialMediaCommand other = (EditSocialMediaCommand) obj;
+
+            return this.editPlatformNameflag == other.editPlatformNameflag
+                && this.index.equals(other.index)
+                && this.newDetails.equals(other.newDetails)
+                && this.target.equals(other.target);
+        }
+
+        return false;
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/edit/EditSocialMediaCommand.java
@@ -58,7 +58,13 @@ public class EditSocialMediaCommand extends EditCommand {
 
         Person targetPersonToEdit = target.targetPerson(lastShownList);
         List<SocialMedia> socialsToEdit = new ArrayList<>(targetPersonToEdit.getSocialMedias());
+
+        if (index.getZeroBased() >= socialsToEdit.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SOCIAL_MEDIA_DISPLAYED_INDEX);
+        }
+
         SocialMedia socialMediaToEdit = socialsToEdit.get(index.getZeroBased());
+
         SocialMedia updatedSocialMedia;
 
         if (editPlatformNameflag) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -81,14 +81,14 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns true if the prefix was used and placed in the argMultiMap
+     * Returns true if the all the {@code prefixes} were used and placed in the argMultiMap.
      */
     public boolean doesPrefixesExist(Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argMultimap.containsKey(prefix));
     }
 
     /**
-     * Returns true if at least one prefix was used and placed in the argMultiMap
+     * Returns true if at least one prefix was used and placed in the argMultiMap.
      */
     public boolean atLeastOnePrefix(Prefix... prefixes) {
         return Stream.of(prefixes).anyMatch(prefix -> argMultimap.containsKey(prefix));

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -28,6 +28,10 @@ import seedu.address.model.tag.Tag;
  */
 public class EditCommandParser implements Parser<EditCommand> {
 
+    private static final Prefix[] ALL_EDIT_PARSER_PREFIXES =
+            new Prefix[]{PREFIX_EMAIL, PREFIX_INDEX, PREFIX_NAME, PREFIX_PHONE,
+                PREFIX_PLATFORM_NAME_FLAG, PREFIX_SOCIAL_MEDIA, PREFIX_TAG};
+
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
@@ -46,10 +50,13 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
+        if (!argMultimap.atLeastOnePrefix(ALL_EDIT_PARSER_PREFIXES)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
-        if (argMultimap.arePrefixesPresent(PREFIX_INDEX)
-                && argMultimap.noOtherPrefixes(PREFIX_INDEX, PREFIX_PLATFORM_NAME_FLAG, PREFIX_SOCIAL_MEDIA)) {
+        if (argMultimap.noOtherPrefixes(PREFIX_INDEX, PREFIX_PLATFORM_NAME_FLAG, PREFIX_SOCIAL_MEDIA)) {
             return new EditSocialMediaCommandParser().parse(args);
         }
 

--- a/src/test/java/seedu/address/logic/commands/edit/EditSocialMediaCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/edit/EditSocialMediaCommandTest.java
@@ -34,7 +34,6 @@ class EditSocialMediaCommandTest {
     @Test
     public void execute_editPlatformName_success() throws CommandException {
         Person editedPerson = model.getSortedAndFilteredPersonList().get(0);
-        EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         SocialMedia socialMediaToEdit = editedPerson.getSocialMedias().get(0);
         EditCommand editCommand = new EditSocialMediaCommand(new Target(INDEX_FIRST_PERSON),
                 INDEX_FIRST_PERSON, validPlatformName.getValue(), true);
@@ -54,7 +53,6 @@ class EditSocialMediaCommandTest {
     @Test
     public void execute_editPlatformDescription_success() throws CommandException {
         Person editedPerson = model.getSortedAndFilteredPersonList().get(0);
-        EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         SocialMedia socialMediaToEdit = editedPerson.getSocialMedias().get(0);
         EditCommand editCommand = new EditSocialMediaCommand(new Target(INDEX_FIRST_PERSON),
                 INDEX_FIRST_PERSON, validPlatformDescription.getValue(), false);
@@ -81,6 +79,18 @@ class EditSocialMediaCommandTest {
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
+
+    @Test
+    public void execute_invalidSocialMediaIndex_failure() {
+        Person person = model.getSortedAndFilteredPersonList().get(0);
+        Index outOfBoundIndex = Index.fromZeroBased(person.getSocialMedias().size());
+
+        EditSocialMediaCommand editCommand = new EditSocialMediaCommand(new Target(INDEX_FIRST_PERSON),
+                outOfBoundIndex, validPlatformName.getValue(), true);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_SOCIAL_MEDIA_DISPLAYED_INDEX);
+
+    }
 
 
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -55,13 +55,11 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        //TODO: can now specify by name so obsolete?
         // no index specified
-        // assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_EDIT_COMMAND_FORMAT);
 
-        //TODO:
         // no field specified
-        //assertParseFailure(parser, "1", EditPersonCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", MESSAGE_INVALID_EDIT_COMMAND_FORMAT);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_EDIT_COMMAND_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -73,7 +73,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_EDIT_COMMAND_FORMAT);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_EDIT_COMMAND_FORMAT);
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 g/ string", MESSAGE_INVALID_EDIT_COMMAND_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/EditSocialMediaCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditSocialMediaCommandParserTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.edit.EditSocialMediaCommand;
+import seedu.address.model.person.Name;
+
+
+public class EditSocialMediaCommandParserTest {
+
+    private static final String MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT =
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditSocialMediaCommand.MESSAGE_USAGE);
+
+    private EditSocialMediaCommandParser parser = new EditSocialMediaCommandParser();
+
+    @Test
+    void parse_missingParts_failure() {
+        // social media index not provided
+        assertParseFailure(parser, "1 i/", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+        assertParseFailure(parser, "TOM i/", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+
+        // social media details not provided
+        assertParseFailure(parser, "1 i/1", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+        assertParseFailure(parser, "TOM i/1", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+
+        // index prefix not provided
+        assertParseFailure(parser, "1 f/", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+        assertParseFailure(parser, "TOM f/", MESSAGE_INVALID_EDIT_SOCIAL_MEDIA_COMMAND_FORMAT);
+    }
+
+    @Test
+    void parse_invalidIndex_failure() {
+
+        //negative index
+        assertParseFailure(parser, "1 i/-1 f/ sm/hello", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "1 i/-1 sm/hello", ParserUtil.MESSAGE_INVALID_INDEX);
+
+        //zero based index
+        assertParseFailure(parser, "1 i/0 f/ sm/hello", ParserUtil.MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, "1 i/0 sm/hello", ParserUtil.MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    void parse_indexTarget_success() {
+
+        EditSocialMediaCommand expectedCommand = new EditSocialMediaCommand(new Target(Index.fromOneBased(1)),
+            Index.fromOneBased(1), "Telegram", true);
+
+        //target person by index
+        assertParseSuccess(parser, "1 i/1 f/ sm/Telegram", expectedCommand);
+
+        //re order arguments
+        assertParseSuccess(parser, "1 f/ i/1 sm/Telegram", expectedCommand);
+        assertParseSuccess(parser, "1 f/ sm/Telegram i/1", expectedCommand);
+        assertParseSuccess(parser, "1 sm/Telegram f/ i/1", expectedCommand);
+        assertParseSuccess(parser, "1 sm/Telegram i/1 f/", expectedCommand);
+        assertParseSuccess(parser, "1 i/1 sm/Telegram f/", expectedCommand);
+
+    }
+
+    @Test
+    void parse_nameTarget_success() {
+        EditSocialMediaCommand expectedCommand = new EditSocialMediaCommand(new Target(new Name("Tom")),
+            Index.fromOneBased(1), "Telegram", true);
+
+        //target person by name
+        assertParseSuccess(parser, "Tom i/1 f/ sm/Telegram", expectedCommand);
+    }
+}


### PR DESCRIPTION
1. Previously, an indexOutOfBoundsException was not handled when the user tried to edit a social media index that is not available.
---------------------------------

2.   Improve the message usage help text when the user uses an invalid syntax for edit command. 

Throw generic edit command usage when user does not supply prefixes relevant to editing social media
> ![image](https://user-images.githubusercontent.com/72195240/162635508-9a58a87a-2c3e-483b-9518-90d1169f709c.png)
> ![image](https://user-images.githubusercontent.com/72195240/162635511-657bbdf0-9b61-4ca2-bdd7-b9d23c0648d2.png)

Throw generic edit command usage when user does not supply prefixes relevant to editing social media

Throw edit social media command usage when user only supplies incomplete social media flags.
> ![image](https://user-images.githubusercontent.com/72195240/162635573-0e67f1de-fbd4-4ccc-8b8c-ddac0122a8f9.png)
